### PR TITLE
Fix to accommodate required type argument format

### DIFF
--- a/Sources/StronglyTypedIDMacros/StronglyTypedIDMacros.swift
+++ b/Sources/StronglyTypedIDMacros/StronglyTypedIDMacros.swift
@@ -39,6 +39,7 @@ extension StronglyTypedIDMacro: DeclarationMacro {
         // Grab the second parameter (backing type).
         let backingIndex = arguments.index(after: arguments.startIndex)
         let backingArgument = arguments[backingIndex].expression
+        let backingTypeName = extractTypeArgument(backingArgument)
 
         // Check if there's adoption arguments and return a simplified declaration if not.
         let firstAdoptionIndex = arguments.index(after: backingIndex)
@@ -47,7 +48,7 @@ extension StronglyTypedIDMacro: DeclarationMacro {
             let result =
                 """
                 struct \(typeName): StronglyTypedID {
-                    var rawValue: \(backingArgument)
+                    var rawValue: \(backingTypeName)
                 }
                 """
             return ["\(raw: result)"]
@@ -55,14 +56,14 @@ extension StronglyTypedIDMacro: DeclarationMacro {
 
         // Grab the adoptions identifiers.
         let adoptions = arguments[firstAdoptionIndex...].map { element in
-            "\(element.expression)"
+            extractTypeArgument(element.expression)
         }
 
         // Build up result.
         let result =
             """
             struct \(typeName): StronglyTypedID, \(adoptions.joined(separator: ", ")) {
-                var rawValue: \(backingArgument)
+                var rawValue: \(backingTypeName)
             }
             """
         return ["\(raw: result)"]
@@ -75,6 +76,23 @@ extension StronglyTypedIDMacro: DeclarationMacro {
             // We're only supposed to call this with `StaticString` parameters, so if we're here it's toolset error or
             // out of sync macro declaration.
             preconditionFailure("Unexpected argument, toolset should only allow `StaticString` literals in")
+        }
+    }
+    
+    private static func extractTypeArgument(_ argument: ExprSyntax) -> String {
+        let memberAccess = argument.as(MemberAccessExprSyntax.self)
+        let declName = argument.as(DeclReferenceExprSyntax.self)
+        
+        if let memberAccess, memberAccess.declName.baseName.text == "self" {
+            if let name = memberAccess.base?.description {
+                return name
+            } else {
+                preconditionFailure("No backing type specified")
+            }
+        } else if let declName {
+            return declName.baseName.text
+        } else {
+            preconditionFailure("Arguments specifying types must be in the form of `T.self`")
         }
     }
 }

--- a/Tests/StronglyTypedIDTests/StronglyTypedIDMacrosTests.swift
+++ b/Tests/StronglyTypedIDTests/StronglyTypedIDMacrosTests.swift
@@ -30,7 +30,7 @@ final class StronglyTypedIDMacroTests: XCTestCase {
     func testBuildSimpleMacro() throws {
         struct TestStruct: Identifiable {
             // Declaration has to happen in a different scope than creation. Within a local `struct` works.
-            #StronglyTypedID("TestID", backing: UUID)
+            #StronglyTypedID("TestID", backing: UUID.self)
 
             var id: TestID
         }
@@ -43,7 +43,7 @@ final class StronglyTypedIDMacroTests: XCTestCase {
     func testBuildMacroWithAdoptions() throws {
         struct TestStruct: Identifiable {
             // Declaration has to happen in a different scope than creation. Within a local `struct` works.
-            #StronglyTypedID("TestID", backing: UUID, adopts: SomeProtocol, SomeOtherProtocol)
+            #StronglyTypedID("TestID", backing: UUID.self, adopts: SomeProtocol.self, SomeOtherProtocol.self)
 
             var id: TestID
         }


### PR DESCRIPTION
Hello,

This is just a quick fix I applied to get StrongTypedID building and functioning again. In my codebase under Xcode 16.4, using bare type names (e.g. `String`) in macro arguments throws a compiler error and requires `.self` to be appended (e.g. `String.self`). The macro wasn't extracting only the type name portion and thus was generating broken code (e.g. `var rawValue: String.self`), which my tweaks fix.

This is my first foray into writing macros so if anything is amiss, let me know and I'll be happy to fix it.